### PR TITLE
[BUGFIX] Fix wrong CDN url generation for files like .youtube or .vimeo

### DIFF
--- a/Classes/EventListener/CdnEventListener.php
+++ b/Classes/EventListener/CdnEventListener.php
@@ -12,7 +12,9 @@ namespace Leuchtfeuer\AwsTools\EventListener;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
 use TYPO3\CMS\Core\Resource\Driver\AbstractHierarchicalFilesystemDriver;
 use TYPO3\CMS\Core\Resource\Event\GeneratePublicUrlForResourceEvent;
+use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Service\EnvironmentService;
@@ -58,13 +60,14 @@ class CdnEventListener implements SingletonInterface
 
     public function onResourceStorageEmitPreGeneratePublicUrlSignal(GeneratePublicUrlForResourceEvent $event): void
     {
-        if (!$this->responsible) {
+        $resource = $event->getResource();
+
+        if (!$this->responsible
+            || ($resource instanceof File && OnlineMediaHelperRegistry::getInstance()->getOnlineMediaHelper($resource) !== false)) {
             return;
         }
 
         $driver = $event->getDriver();
-        $resource = $event->getResource();
-
         if ($driver instanceof AbstractHierarchicalFilesystemDriver && $resource instanceof FileInterface) {
             $publicUrl = $driver->getPublicUrl($resource->getIdentifier());
             $event->setPublicUrl($this->host . $publicUrl);


### PR DESCRIPTION
There is a problem with .youtube or .vimeo files and an active CDN. For example:

If you try to get a URL to a YouTube or Vimeo video using a Fluid View Helper like this:
```
<f:link.typolink parameter="{file.publicUrl}"></f:link.typolink>
```
The extension resolves the URL with the CDN url like this:
```
https://cdn.domain.com/fileadmin/user_uploads/video_file.youtube
```
But what I need is acutally the URL to the video on YouTube/Vimeo:
```
https://www.youtube.com/watch?v=dQw4w9WgXcQ
```
The processing of .youtube/.vimeo files will take place AFTER the event of this extension but then the wrong CDN link is already generated (see https://github.com/TYPO3/typo3/blob/808ef61a53bc1e7ef65b715c13727b0f2d086c24/typo3/sysext/core/Classes/Resource/ResourceStorage.php#L1393C39-L1393C39).

I fixed the problem by checking in the CDN event if the requested file is not part of the OnlineMediaHelper class and skip the CDN link generation.