### PR TITLE
[BUGFIX] Fix prefix of generatePublicUrlForResource event-listener

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -24,7 +24,7 @@ services:
   Leuchtfeuer\AwsTools\EventListener\CdnEventListener:
     tags:
       - name: event.listener
-        identifier: sdl.generatePublicUrlForResource
+        identifier: awstools.generatePublicUrlForResource
         method: onResourceStorageEmitPreGeneratePublicUrlSignal
         event: TYPO3\CMS\Core\Resource\Event\GeneratePublicUrlForResourceEvent
 


### PR DESCRIPTION
#14 This caused secure-downloads to not work as intended.