### PR TITLE
[TASK] Ensure language array is set

### DIFF
--- a/Classes/EventListener/CdnEventListener.php
+++ b/Classes/EventListener/CdnEventListener.php
@@ -45,10 +45,16 @@ class CdnEventListener implements SingletonInterface
                         break;
                     }
                 }
+
+                if (count($language) === 0 && $site = reset($allSites)) {
+                    // if no site matches, get the first as default
+                    $languages = $site->getAttribute('languages');
+                    $language = reset($languages);
+                }
             }
 
             $replacer = $GLOBALS['TSFE']->config['config']['tx_awstools.']['replacer.'] ?? [];
-            $this->responsible = filter_var($language['awstools_cdn_enabled'], FILTER_VALIDATE_BOOLEAN) === true && !empty($language['awstools_cdn_host'] && $replacer['eventListener'] === '1');
+            $this->responsible = isset($language['awstools_cdn_enabled']) && filter_var($language['awstools_cdn_enabled'], FILTER_VALIDATE_BOOLEAN) === true && !empty($language['awstools_cdn_host'] && $replacer['eventListener'] === '1');
 
             if ($this->responsible) {
                 $this->host = $language['awstools_cdn_host'];


### PR DESCRIPTION
Provide site language configuration in cli context and ensure $language['awstools_cdn_enabled'] is set.

When called from cli (e.g. from a scheduler task), site language could not be fetched. Now a fallback from first site configuration is used.