### PR TITLE
[TASK] Unify CDN flag evaluation [TER-497]

### DIFF
--- a/Classes/Configuration/CdnConfiguration.php
+++ b/Classes/Configuration/CdnConfiguration.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "AWS Tools" extension.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\AwsTools\Configuration;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\TypoScript\FrontendTypoScript;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+
+/**
+ * Single source of truth for the question "should CDN rewriting happen?".
+ *
+ * Both the event listener (file URLs) and the middleware (HTML content) ask this class,
+ * so that a site language and TypoScript setup can never activate one and not the other.
+ */
+class CdnConfiguration
+{
+    public const REPLACER_EVENT_LISTENER = 'eventListener';
+
+    public const REPLACER_MIDDLEWARE = 'middleware';
+
+    public function __construct(private readonly ConfigurationManagerInterface $configurationManager) {}
+
+    /**
+     * @param array<string, mixed> $language Site language configuration as array
+     */
+    public function isReplacerEnabled(string $replacer, array $language, ?ServerRequestInterface $request): bool
+    {
+        if (!$this->isFlagEnabled($language['awstools_cdn_enabled'] ?? null) || $this->resolveHost($language) === '') {
+            return false;
+        }
+
+        $config = $this->getConfig($request);
+
+        if ($config === null) {
+            // eID contexts (e.g. tx_cms_showpic) have no TypoScript, so the site language decides alone
+            return true;
+        }
+
+        $replacerConfig = $config['replacer.'] ?? [];
+
+        return $this->isFlagEnabled($config['enabled'] ?? null)
+            && is_array($replacerConfig)
+            && $this->isFlagEnabled($replacerConfig[$replacer] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $language Site language configuration as array
+     */
+    public function resolveHost(array $language): string
+    {
+        return rtrim((string)($language['awstools_cdn_host'] ?? ''), '/');
+    }
+
+    /**
+     * @return list<array{search: string, replace: string}>
+     */
+    public function getPatterns(?ServerRequestInterface $request): array
+    {
+        $rawPatterns = ($this->getConfig($request) ?? [])['patterns.'] ?? [];
+
+        if (!is_array($rawPatterns)) {
+            return [];
+        }
+
+        $patterns = [];
+
+        foreach ($rawPatterns as $rawPattern) {
+            if (is_array($rawPattern) && isset($rawPattern['search'], $rawPattern['replace'])) {
+                $patterns[] = [
+                    'search' => (string)$rawPattern['search'],
+                    'replace' => (string)$rawPattern['replace'],
+                ];
+            }
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * @return array<string, mixed>|null Null means TypoScript is unavailable, an empty array means it holds no configuration
+     */
+    private function getConfig(?ServerRequestInterface $request): ?array
+    {
+        $frontendTypoScript = $request?->getAttribute('frontend.typoscript');
+
+        if ($frontendTypoScript instanceof FrontendTypoScript) {
+            try {
+                return $this->extractConfig($frontendTypoScript->getConfigArray());
+            } catch (\RuntimeException) {
+                // config array not initialised yet, fall through to the Extbase configuration manager
+            }
+        }
+
+        try {
+            $typoScript = $this->configurationManager
+                ->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+
+            if ($typoScript !== []) {
+                $config = $typoScript['config'] ?? [];
+
+                return $this->extractConfig(is_array($config) ? $config : []);
+            }
+        } catch (\Exception) {
+            // no page context available
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $configArray
+     * @return array<string, mixed>
+     */
+    private function extractConfig(array $configArray): array
+    {
+        $config = $configArray['tx_awstools.'] ?? [];
+
+        return is_array($config) ? $config : [];
+    }
+
+    private function isFlagEnabled(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/Classes/Configuration/CdnConfiguration.php
+++ b/Classes/Configuration/CdnConfiguration.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Leuchtfeuer\AwsTools\Configuration;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\TypoScript\FrontendTypoScript;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
@@ -23,11 +25,15 @@ use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
  * Both the event listener (file URLs) and the middleware (HTML content) ask this class,
  * so that a site language and TypoScript setup can never activate one and not the other.
  */
-class CdnConfiguration
+class CdnConfiguration implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     public const REPLACER_EVENT_LISTENER = 'eventListener';
 
     public const REPLACER_MIDDLEWARE = 'middleware';
+
+    private const SUPPORTED_HOST_SCHEMES = ['http', 'https'];
 
     public function __construct(private readonly ConfigurationManagerInterface $configurationManager) {}
 
@@ -55,11 +61,31 @@ class CdnConfiguration
     }
 
     /**
+     * Returns an empty string for anything that is not an absolute http(s) URL, so that a
+     * malformed CDN host disables the rewriting instead of producing broken public URLs.
+     *
      * @param array<string, mixed> $language Site language configuration as array
      */
     public function resolveHost(array $language): string
     {
-        return rtrim((string)($language['awstools_cdn_host'] ?? ''), '/');
+        $host = rtrim((string)($language['awstools_cdn_host'] ?? ''), '/');
+
+        if ($host === '') {
+            return '';
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_URL) === false
+            || !in_array(parse_url($host, PHP_URL_SCHEME), self::SUPPORTED_HOST_SCHEMES, true)
+        ) {
+            $this->logger?->warning(
+                'CDN host of the site language is not an absolute http(s) URL, CDN rewriting is disabled.',
+                ['host' => $host]
+            );
+
+            return '';
+        }
+
+        return $host;
     }
 
     /**
@@ -97,8 +123,12 @@ class CdnConfiguration
         if ($frontendTypoScript instanceof FrontendTypoScript) {
             try {
                 return $this->extractConfig($frontendTypoScript->getConfigArray());
-            } catch (\RuntimeException) {
+            } catch (\RuntimeException $exception) {
                 // config array not initialised yet, fall through to the Extbase configuration manager
+                $this->logger?->debug(
+                    'Frontend TypoScript holds no config array, falling back to the configuration manager.',
+                    ['exception' => $exception]
+                );
             }
         }
 
@@ -111,8 +141,12 @@ class CdnConfiguration
 
                 return $this->extractConfig(is_array($config) ? $config : []);
             }
-        } catch (\Exception) {
-            // no page context available
+        } catch (\Exception $exception) {
+            // no page context available, e.g. in eID requests
+            $this->logger?->debug(
+                'TypoScript is unavailable, the site language configuration decides on its own.',
+                ['exception' => $exception]
+            );
         }
 
         return null;

--- a/Classes/EventListener/CdnEventListener.php
+++ b/Classes/EventListener/CdnEventListener.php
@@ -11,6 +11,7 @@
 
 namespace Leuchtfeuer\AwsTools\EventListener;
 
+use Leuchtfeuer\AwsTools\Configuration\CdnConfiguration;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\Resource\Driver\AbstractHierarchicalFilesystemDriver;
@@ -19,8 +20,6 @@ use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
 use TYPO3\CMS\Core\SingletonInterface;
-use TYPO3\CMS\Core\TypoScript\FrontendTypoScript;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 class CdnEventListener implements SingletonInterface
 {
@@ -31,7 +30,7 @@ class CdnEventListener implements SingletonInterface
     private string $host = '';
 
     public function __construct(
-        private readonly ConfigurationManagerInterface $configurationManager,
+        private readonly CdnConfiguration $cdnConfiguration,
         private readonly OnlineMediaHelperRegistry $onlineMediaHelperRegistry
     ) {}
 
@@ -71,50 +70,12 @@ class CdnEventListener implements SingletonInterface
 
         $language = $this->resolveLanguage($request);
 
-        if (empty($language['awstools_cdn_enabled']) || empty($language['awstools_cdn_host'])) {
-            return;
-        }
-
-        $this->responsible = $this->isCdnEnabledInTypoScript($request);
+        $this->responsible = $this->cdnConfiguration
+            ->isReplacerEnabled(CdnConfiguration::REPLACER_EVENT_LISTENER, $language, $request);
 
         if ($this->responsible) {
-            $this->host = $language['awstools_cdn_host'];
+            $this->host = $this->cdnConfiguration->resolveHost($language);
         }
-    }
-
-    /**
-     * Checks TypoScript config.tx_awstools for CDN activation flags.
-     *
-     * In eID contexts (e.g. tx_cms_showpic) TypoScript is not bootstrapped — returns true
-     * so that CDN rewriting follows the site language config alone.
-     */
-    private function isCdnEnabledInTypoScript(ServerRequestInterface $request): bool
-    {
-        // TYPO3 14 native: available on full frontend page requests
-        $frontendTypoScript = $request->getAttribute('frontend.typoscript');
-        if ($frontendTypoScript instanceof FrontendTypoScript) {
-            try {
-                $config = $frontendTypoScript->getConfigArray()['tx_awstools.'] ?? [];
-                return !empty($config['enabled']) && !empty($config['replacer.']['eventListener']);
-            } catch (\RuntimeException) {
-                // config not yet initialised — treat as unavailable
-            }
-        }
-
-        // Extbase fallback: works on normal frontend pages, may fail in eID contexts
-        try {
-            $typoscript = $this->configurationManager
-                ->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
-            if ($typoscript !== []) {
-                $config = $typoscript['config']['tx_awstools.'] ?? [];
-                return !empty($config['enabled']) && !empty($config['replacer.']['eventListener']);
-            }
-        } catch (\Exception) {
-            // ConfigurationManager unavailable (no page context)
-        }
-
-        // eID context: TypoScript not bootstrapped — language config is sufficient
-        return true;
     }
 
     private function resolveRequest(): ?ServerRequestInterface

--- a/Classes/Middleware/ContentReplaceMiddleware.php
+++ b/Classes/Middleware/ContentReplaceMiddleware.php
@@ -11,6 +11,7 @@
 
 namespace Leuchtfeuer\AwsTools\Middleware;
 
+use Leuchtfeuer\AwsTools\Configuration\CdnConfiguration;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -19,6 +20,8 @@ use TYPO3\CMS\Core\Http\Stream;
 
 class ContentReplaceMiddleware implements MiddlewareInterface
 {
+    public function __construct(private readonly CdnConfiguration $cdnConfiguration) {}
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $siteLanguage = $request->getAttribute('language');
@@ -27,19 +30,18 @@ class ContentReplaceMiddleware implements MiddlewareInterface
         }
         $language = $siteLanguage->toArray();
         $response = $handler->handle($request);
-        $config = $request->getAttribute('frontend.typoscript')?->getConfigArray()['tx_awstools.'] ?? [];
 
-        if (empty($config['enabled']) || filter_var($language['awstools_cdn_enabled'], FILTER_VALIDATE_BOOLEAN) === false || empty($language['awstools_cdn_host']) || $config['replacer.']['middleware'] !== '1') {
+        if (!$this->cdnConfiguration->isReplacerEnabled(CdnConfiguration::REPLACER_MIDDLEWARE, $language, $request)) {
             return $response;
         }
 
-        $host = rtrim((string)$language['awstools_cdn_host'], '/');
+        $host = $this->cdnConfiguration->resolveHost($language);
         $patterns = [];
         $replacements = [];
 
-        foreach ($config['patterns.'] ?? [] as $search) {
-            $patterns[] = sprintf('#%s#', $search['search']);
-            $replacements[] = sprintf($search['replace'], $host);
+        foreach ($this->cdnConfiguration->getPatterns($request) as $pattern) {
+            $patterns[] = sprintf('#%s#', $pattern['search']);
+            $replacements[] = sprintf($pattern['replace'], $host);
         }
 
         if ($patterns !== []) {

--- a/Documentation/About/Changelog/14-0-1.rst
+++ b/Documentation/About/Changelog/14-0-1.rst
@@ -1,0 +1,28 @@
+.. include:: ../../Includes.txt
+
+===========================
+Version 14.0.1 - 2026/08/12
+===========================
+
+* Evaluate all CDN activation flags with the same boolean semantics
+* Fix duplicate slashes in rewritten file URLs when the CDN host ends with a slash
+* Fix undefined array key warnings when a site language has no CDN configuration
+
+.. attention::
+
+   Site language values such as ``false``, ``off`` or ``no`` in **Enable CDN** are now
+   consistently treated as disabled. Previously the file URL rewriting activated on such
+   values while the HTML content replacement did not.
+
+Download
+========
+
+Download this version from the `TYPO3 extension repository <https://extensions.typo3.org/extension/aws_tools/>`__ or from
+`GitHub <https://github.com/Leuchtfeuer/typo3-aws-tools/releases/tag/v14.0.1>`__.
+
+All Changes
+===========
+
+This is a list of all changes in this release::
+
+    2026-08-11 [TASK] Unify CDN flag evaluation in CdnConfiguration [TER-497] (Commit 6eaf515 by Oliver Heins)

--- a/Documentation/About/Changelog/14-0-1.rst
+++ b/Documentation/About/Changelog/14-0-1.rst
@@ -7,12 +7,21 @@ Version 14.0.1 - 2026/08/12
 * Evaluate all CDN activation flags with the same boolean semantics
 * Fix duplicate slashes in rewritten file URLs when the CDN host ends with a slash
 * Fix undefined array key warnings when a site language has no CDN configuration
+* Validate the CDN host and disable the rewriting instead of emitting broken public URLs
+* Log discarded CDN hosts and unavailable TypoScript contexts
 
 .. attention::
 
    Site language values such as ``false``, ``off`` or ``no`` in **Enable CDN** are now
    consistently treated as disabled. Previously the file URL rewriting activated on such
    values while the HTML content replacement did not.
+
+.. attention::
+
+   **CDN Host** must now be an absolute ``http://`` or ``https://`` URL, as stated by its
+   label. Any other value - including a protocol relative host such as
+   ``//cdn.example.com`` - is discarded and disables the CDN rewriting for that site
+   language. A discarded host is logged with the ``warning`` level.
 
 Download
 ========

--- a/Documentation/About/Changelog/14-0-1.rst
+++ b/Documentation/About/Changelog/14-0-1.rst
@@ -34,4 +34,5 @@ All Changes
 
 This is a list of all changes in this release::
 
+    2026-08-12 [TASK] Validate CDN host and log discarded configuration [TER-497] (Commit 6e9ced2 by Oliver Heins)
     2026-08-11 [TASK] Unify CDN flag evaluation in CdnConfiguration [TER-497] (Commit 6eaf515 by Oliver Heins)

--- a/Documentation/About/Changelog/Index.rst
+++ b/Documentation/About/Changelog/Index.rst
@@ -15,6 +15,7 @@ List of Versions
 .. toctree::
    :titlesonly:
 
+   14-0-1
    14-0-0
    13-0-0
    12-0-1

--- a/Documentation/Admin/Configuration/Index.rst
+++ b/Documentation/Admin/Configuration/Index.rst
@@ -23,6 +23,12 @@ configuration of the page configuration. The CDN can be enabled or disabled per 
 
    CDN Settings within the Site Configuration
 
+.. note::
+
+   **CDN Host** must be an absolute URL including the scheme, e.g. ``https://cdn.example.com``.
+   Only ``http`` and ``https`` are accepted. Any other value is discarded, disables the CDN
+   rewriting for that site language, and is logged with the ``warning`` level.
+
 .. _admin-configuration-rewriteFilePaths:
 
 Rewrite File Paths

--- a/Tests/Unit/Configuration/CdnConfigurationTest.php
+++ b/Tests/Unit/Configuration/CdnConfigurationTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\TypoScript\AST\Node\RootNode;
 use TYPO3\CMS\Core\TypoScript\FrontendTypoScript;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
@@ -228,6 +229,39 @@ final class CdnConfigurationTest extends UnitTestCase
         ));
     }
 
+    #[Test]
+    public function unavailableTypoScriptIsLoggedForDebugging(): void
+    {
+        $this->configurationManager->method('getConfiguration')
+            ->willThrowException(new \RuntimeException('no page context', 1770000003));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('debug');
+        $this->subject->setLogger($logger);
+
+        $this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $this->createRequest(null)
+        );
+    }
+
+    #[Test]
+    public function uninitialisedConfigArrayIsLoggedForDebugging(): void
+    {
+        $this->configurationManager->method('getConfiguration')->willReturn(['config' => []]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('debug');
+        $this->subject->setLogger($logger);
+
+        $this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $this->createRequest(new FrontendTypoScript(new RootNode(), [], [], []))
+        );
+    }
+
     /**
      * @return \Generator<string, array{array<string, mixed>, string}>
      */
@@ -236,8 +270,25 @@ final class CdnConfigurationTest extends UnitTestCase
         yield 'host without trailing slash' => [['awstools_cdn_host' => 'https://cdn.example.com'], 'https://cdn.example.com'];
         yield 'host with trailing slash' => [['awstools_cdn_host' => 'https://cdn.example.com/'], 'https://cdn.example.com'];
         yield 'host with multiple trailing slashes' => [['awstools_cdn_host' => 'https://cdn.example.com//'], 'https://cdn.example.com'];
+        yield 'host with unencrypted scheme' => [['awstools_cdn_host' => 'http://cdn.example.com'], 'http://cdn.example.com'];
+        yield 'host with port' => [['awstools_cdn_host' => 'https://cdn.example.com:8080'], 'https://cdn.example.com:8080'];
+        yield 'host with path' => [['awstools_cdn_host' => 'https://cdn.example.com/assets/'], 'https://cdn.example.com/assets'];
         yield 'missing host' => [[], ''];
         yield 'empty host' => [['awstools_cdn_host' => ''], ''];
+    }
+
+    /**
+     * @return \Generator<string, array{array<string, mixed>}>
+     */
+    public static function malformedHostDataProvider(): \Generator
+    {
+        yield 'malformed url' => [['awstools_cdn_host' => 'https:///www.example.org|']];
+        yield 'missing scheme' => [['awstools_cdn_host' => 'cdn.example.com']];
+        yield 'protocol relative host' => [['awstools_cdn_host' => '//cdn.example.com']];
+        yield 'unsupported scheme' => [['awstools_cdn_host' => 'javascript:alert(1)']];
+        yield 'data scheme' => [['awstools_cdn_host' => 'data:text/html,<h1>x</h1>']];
+        yield 'whitespace only' => [['awstools_cdn_host' => '   ']];
+        yield 'slashes only' => [['awstools_cdn_host' => '///']];
     }
 
     #[Test]
@@ -245,6 +296,52 @@ final class CdnConfigurationTest extends UnitTestCase
     public function hostIsNormalised(array $language, string $expectation): void
     {
         self::assertSame($expectation, $this->subject->resolveHost($language));
+    }
+
+    #[Test]
+    #[DataProvider('malformedHostDataProvider')]
+    public function malformedHostIsDiscarded(array $language): void
+    {
+        self::assertSame('', $this->subject->resolveHost($language));
+    }
+
+    #[Test]
+    #[DataProvider('malformedHostDataProvider')]
+    public function malformedHostDisablesRewritingDespiteEnabledFlags(array $language): void
+    {
+        $request = $this->createRequestWithTypoScript([
+            'enabled' => '1',
+            'replacer.' => ['eventListener' => '1'],
+        ]);
+
+        self::assertFalse($this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            ['awstools_cdn_enabled' => '1'] + $language,
+            $request
+        ));
+    }
+
+    #[Test]
+    public function malformedHostIsLogged(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')->with(
+            self::anything(),
+            ['host' => 'cdn.example.com']
+        );
+        $this->subject->setLogger($logger);
+
+        $this->subject->resolveHost(['awstools_cdn_host' => 'cdn.example.com']);
+    }
+
+    #[Test]
+    public function validHostIsNotLogged(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+        $this->subject->setLogger($logger);
+
+        $this->subject->resolveHost(['awstools_cdn_host' => 'https://cdn.example.com']);
     }
 
     #[Test]

--- a/Tests/Unit/Configuration/CdnConfigurationTest.php
+++ b/Tests/Unit/Configuration/CdnConfigurationTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "AWS Tools" extension.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\AwsTools\Tests\Unit\Configuration;
+
+use Leuchtfeuer\AwsTools\Configuration\CdnConfiguration;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\TypoScript\AST\Node\RootNode;
+use TYPO3\CMS\Core\TypoScript\FrontendTypoScript;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class CdnConfigurationTest extends UnitTestCase
+{
+    private ConfigurationManagerInterface&Stub $configurationManager;
+
+    private CdnConfiguration $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurationManager = $this->createStub(ConfigurationManagerInterface::class);
+        $this->subject = new CdnConfiguration($this->configurationManager);
+    }
+
+    /**
+     * @return \Generator<string, array{mixed, bool}>
+     */
+    public static function booleanFlagValueDataProvider(): \Generator
+    {
+        yield 'TypoScript string one' => ['1', true];
+        yield 'integer one' => [1, true];
+        yield 'boolean true' => [true, true];
+        yield 'string true' => ['true', true];
+        yield 'string on' => ['on', true];
+        yield 'string yes' => ['yes', true];
+        yield 'TypoScript string zero' => ['0', false];
+        yield 'integer zero' => [0, false];
+        yield 'boolean false' => [false, false];
+        yield 'string false' => ['false', false];
+        yield 'string off' => ['off', false];
+        yield 'string no' => ['no', false];
+        yield 'empty string' => ['', false];
+        yield 'null' => [null, false];
+        yield 'arbitrary string' => ['lorem', false];
+    }
+
+    #[Test]
+    #[DataProvider('booleanFlagValueDataProvider')]
+    public function siteLanguageFlagIsEvaluatedAsBoolean(mixed $flagValue, bool $expectation): void
+    {
+        $request = $this->createRequestWithTypoScript([
+            'enabled' => '1',
+            'replacer.' => ['eventListener' => '1'],
+        ]);
+
+        self::assertSame($expectation, $this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage($flagValue),
+            $request
+        ));
+    }
+
+    #[Test]
+    #[DataProvider('booleanFlagValueDataProvider')]
+    public function typoScriptEnabledFlagIsEvaluatedAsBoolean(mixed $flagValue, bool $expectation): void
+    {
+        $request = $this->createRequestWithTypoScript([
+            'enabled' => $flagValue,
+            'replacer.' => ['eventListener' => '1'],
+        ]);
+
+        self::assertSame($expectation, $this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $request
+        ));
+    }
+
+    #[Test]
+    #[DataProvider('booleanFlagValueDataProvider')]
+    public function replacerFlagIsEvaluatedAsBoolean(mixed $flagValue, bool $expectation): void
+    {
+        $request = $this->createRequestWithTypoScript([
+            'enabled' => '1',
+            'replacer.' => ['eventListener' => $flagValue],
+        ]);
+
+        self::assertSame($expectation, $this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $request
+        ));
+    }
+
+    #[Test]
+    public function replacersAreEvaluatedIndependently(): void
+    {
+        $request = $this->createRequestWithTypoScript([
+            'enabled' => '1',
+            'replacer.' => [
+                'eventListener' => '1',
+                'middleware' => '0',
+            ],
+        ]);
+        $language = $this->createLanguage('1');
+
+        self::assertTrue($this->subject->isReplacerEnabled(CdnConfiguration::REPLACER_EVENT_LISTENER, $language, $request));
+        self::assertFalse($this->subject->isReplacerEnabled(CdnConfiguration::REPLACER_MIDDLEWARE, $language, $request));
+    }
+
+    #[Test]
+    public function missingReplacerFlagDisablesRewriting(): void
+    {
+        $request = $this->createRequestWithTypoScript(['enabled' => '1']);
+
+        self::assertFalse($this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $request
+        ));
+    }
+
+    #[Test]
+    public function missingHostDisablesRewritingDespiteEnabledFlags(): void
+    {
+        $request = $this->createRequestWithTypoScript([
+            'enabled' => '1',
+            'replacer.' => ['eventListener' => '1'],
+        ]);
+
+        self::assertFalse($this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            ['awstools_cdn_enabled' => '1'],
+            $request
+        ));
+    }
+
+    #[Test]
+    public function configurationManagerIsUsedWhenRequestHasNoFrontendTypoScript(): void
+    {
+        $this->configurationManager->method('getConfiguration')->willReturn([
+            'config' => [
+                'tx_awstools.' => [
+                    'enabled' => '1',
+                    'replacer.' => ['eventListener' => '1'],
+                ],
+            ],
+        ]);
+
+        self::assertTrue($this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $this->createRequest(null)
+        ));
+    }
+
+    #[Test]
+    public function configurationManagerIsUsedWhenFrontendTypoScriptHasNoConfigArray(): void
+    {
+        $this->configurationManager->method('getConfiguration')->willReturn([
+            'config' => [
+                'tx_awstools.' => [
+                    'enabled' => '1',
+                    'replacer.' => ['eventListener' => '0'],
+                ],
+            ],
+        ]);
+
+        $frontendTypoScript = new FrontendTypoScript(new RootNode(), [], [], []);
+
+        self::assertFalse($this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $this->createRequest($frontendTypoScript)
+        ));
+    }
+
+    #[Test]
+    public function availableTypoScriptWithoutExtensionConfigurationDisablesRewriting(): void
+    {
+        $this->configurationManager->method('getConfiguration')->willReturn(['config' => []]);
+
+        self::assertFalse($this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $this->createRequest(null)
+        ));
+    }
+
+    #[Test]
+    public function unavailableTypoScriptFallsBackToSiteLanguageConfiguration(): void
+    {
+        $this->configurationManager->method('getConfiguration')
+            ->willThrowException(new \RuntimeException('no page context', 1770000000));
+
+        self::assertTrue($this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('1'),
+            $this->createRequest(null)
+        ));
+    }
+
+    #[Test]
+    public function unavailableTypoScriptStillHonoursDisabledSiteLanguage(): void
+    {
+        $this->configurationManager->method('getConfiguration')
+            ->willThrowException(new \RuntimeException('no page context', 1770000001));
+
+        self::assertFalse($this->subject->isReplacerEnabled(
+            CdnConfiguration::REPLACER_EVENT_LISTENER,
+            $this->createLanguage('0'),
+            $this->createRequest(null)
+        ));
+    }
+
+    /**
+     * @return \Generator<string, array{array<string, mixed>, string}>
+     */
+    public static function hostDataProvider(): \Generator
+    {
+        yield 'host without trailing slash' => [['awstools_cdn_host' => 'https://cdn.example.com'], 'https://cdn.example.com'];
+        yield 'host with trailing slash' => [['awstools_cdn_host' => 'https://cdn.example.com/'], 'https://cdn.example.com'];
+        yield 'host with multiple trailing slashes' => [['awstools_cdn_host' => 'https://cdn.example.com//'], 'https://cdn.example.com'];
+        yield 'missing host' => [[], ''];
+        yield 'empty host' => [['awstools_cdn_host' => ''], ''];
+    }
+
+    #[Test]
+    #[DataProvider('hostDataProvider')]
+    public function hostIsNormalised(array $language, string $expectation): void
+    {
+        self::assertSame($expectation, $this->subject->resolveHost($language));
+    }
+
+    #[Test]
+    public function patternsAreNormalisedAndMalformedEntriesAreSkipped(): void
+    {
+        $request = $this->createRequestWithTypoScript([
+            'patterns.' => [
+                '10.' => ['search' => '"/typo3temp/', 'replace' => '"%s/typo3temp/'],
+                '20.' => ['search' => '"/typo3conf/'],
+                '30.' => 'not an array',
+            ],
+        ]);
+
+        self::assertSame(
+            [['search' => '"/typo3temp/', 'replace' => '"%s/typo3temp/']],
+            $this->subject->getPatterns($request)
+        );
+    }
+
+    #[Test]
+    public function patternsAreEmptyWhenTypoScriptIsUnavailable(): void
+    {
+        $this->configurationManager->method('getConfiguration')
+            ->willThrowException(new \RuntimeException('no page context', 1770000002));
+
+        self::assertSame([], $this->subject->getPatterns($this->createRequest(null)));
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createRequestWithTypoScript(array $config): ServerRequestInterface
+    {
+        $frontendTypoScript = new FrontendTypoScript(new RootNode(), [], [], []);
+        $frontendTypoScript->setConfigArray(['tx_awstools.' => $config]);
+
+        return $this->createRequest($frontendTypoScript);
+    }
+
+    private function createRequest(?FrontendTypoScript $frontendTypoScript): ServerRequestInterface
+    {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getAttribute')->willReturnCallback(
+            static fn (string $name): ?FrontendTypoScript => $name === 'frontend.typoscript' ? $frontendTypoScript : null
+        );
+
+        return $request;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createLanguage(mixed $enabled): array
+    {
+        return [
+            'awstools_cdn_enabled' => $enabled,
+            'awstools_cdn_host' => 'https://cdn.example.com',
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "extra": {
         "typo3/cms": {
             "extension-key": "aws_tools",
-            "version": "14.0.0"
+            "version": "14.0.1"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,11 @@
             "Leuchtfeuer\\AwsTools\\": "Classes/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Leuchtfeuer\\AwsTools\\Tests\\": "Tests/"
+        }
+    },
     "config": {
         "platform": {
             "php": "8.2"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF['aws_tools'] = [
     'title' => 'Amazon Web Services (AWS) Toolbox',
     'description' => 'This extension connects your TYPO3 instance to Amazon CloudFront. It rewrites all file paths in the frontend to match your CDN domain. You also have the possibility to invalidate Amazon CloudFront entries.',
-    'version' => '14.0.0',
+    'version' => '14.0.1',
     'category' => 'misc',
     'constraints' => [
         'depends' => [


### PR DESCRIPTION
The CDN flags were evaluated with three different notions of truth, spread across
`CdnEventListener` and `ContentReplaceMiddleware`. The same site language field could therefore
activate the file URL rewriting but not the HTML content replacement. The new
`Configuration\CdnConfiguration` is now the single place deciding this: all flags go through one
`filter_var(..., FILTER_VALIDATE_BOOLEAN)`, the host is normalised in one place, and "TypoScript
unavailable" (eID, fail open) is distinguishable from "TypoScript available but not configured".

Behaviour change: values such as `false`, `off` or `no` in **Enable CDN** are now consistently
treated as disabled.
